### PR TITLE
Update response for action.devices.EXECUTE

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1625,7 +1625,9 @@ var handleControl = function (event, input) {
         })
     });
 
-    return responses;
+    //create response payload
+    let res = {commands: responses};
+    return res;
 
 }; // handleControl
 


### PR DESCRIPTION
Google updated the EXECUTE response payload and requires the commands object in the payload.